### PR TITLE
GAE servlet lets React router handle client urls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ npm start
 4. Make changes to java files and re-compile the Appengine devserver.
 5. Test changes on http://localhost:3000 to see if the server changes worked. Your changes won't show up on localhost:8080 because the server is running ui-less.
 
-## Useful Debugging Tools
+## Useful Tools
 
 - [React Developer Tools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en)
 - [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en)
+- Java formatter, run from top level directory `java -jar googleformatter.jar --replace $(git ls-files|grep \.java$)`

--- a/client/src/components/page/UserPage.js
+++ b/client/src/components/page/UserPage.js
@@ -20,6 +20,7 @@ import { connect } from 'react-redux';
 
 import 'css/userPage.css';
 import { HIDDEN } from 'constants/css.js';
+import { MESSAGE } from 'constants/links.js';
 import Message from 'components/ui/Message.js';
 
 /** Gets the parameters from the url. Parameters are after the ? in the url. */
@@ -54,7 +55,7 @@ class UserPage extends Component {
 
   /** Fetches messages and add them to the page. */
   fetchMessages() {
-    const url = '/gap/messages?user=' + userEmailParam;
+    const url = MESSAGE + '?user=' + userEmailParam;
     fetch(url)
       .then(response => {
         return response.json();
@@ -72,7 +73,7 @@ class UserPage extends Component {
     // another user's page. Some controls such as the message form will hide if
     // the user is not viewing their own page.
     const hiddenIfViewingOther = userEmail !== userEmailParam ? HIDDEN : null;
-    const hiddenIfHasMessages = messages ? HIDDEN : null;
+    const hiddenIfHasMessages = messages > 0 ? HIDDEN : null;
 
     const messagesUi = messages
       ? messages.map(message => createMessageUi(message))
@@ -81,10 +82,7 @@ class UserPage extends Component {
     return (
       <div className='container'>
         <h1 className='center'>{userEmailParam}</h1>
-        <form
-          action='/gap/messages'
-          method='POST'
-          className={hiddenIfViewingOther}>
+        <form action={MESSAGE} method='POST' className={hiddenIfViewingOther}>
           Enter a new message:
           <br />
           <textarea name='text' className='message-input' />

--- a/client/src/constants/links.js
+++ b/client/src/constants/links.js
@@ -19,15 +19,21 @@
  * Client links do not need redirect to an external server.
  */
 
+/** Prefix for all servlet fetch links. */
+const servletPrefix = '/api';
+
+/** Link to the login servlet. */
+export const LOGIN = servletPrefix + '/login';
+/** Link to the logout servlet. */
+export const LOGOUT = servletPrefix + '/logout';
+/**Link to the login status servlet. */
+export const LOGIN_STATUS = servletPrefix + '/login-status';
+/** Link to the message servlet.  */
+export const MESSAGE = servletPrefix + '/messages';
+
 /** Client link to the about page. */
 export const ABOUT_US = '/aboutus';
 /** Client link to the home page. */
 export const HOME = '/';
-/** Google App Engine link to the login servlet. */
-export const LOGIN = '/gap/login';
-/** Google App Engine link to the login status servlet. */
-export const LOGIN_STATUS = '/gap/login-status';
-/** Google App Engine link to the logout servlet. */
-export const LOGOUT = '/gap/logout';
 /** Client link to the user's page. */
 export const USER_PAGE = '/userpage';

--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -26,7 +26,7 @@ const proxy = require('http-proxy-middleware');
 
 module.exports = function(app) {
   /** Proxies calls to our Google App Engine. */
-  app.use(proxy('/gap/*', { target: 'http://localhost:8080/' }));
+  app.use(proxy('/api/*', { target: 'http://localhost:8080/' }));
   /** Proxies calls to the Google Login Server. */
   app.use(proxy('/_ah/*', { target: 'http://localhost:8080/' }));
 };

--- a/server/src/main/java/com/google/codeu/filters/SinglePageAppFilter.java
+++ b/server/src/main/java/com/google/codeu/filters/SinglePageAppFilter.java
@@ -1,0 +1,39 @@
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+
+/** Filters all paths back to index.html due to SPA client structure. */
+@WebFilter("/*")
+public class SinglePageAppFilter implements Filter {
+  @Override
+  public void init(FilterConfig filterConfig) {}
+
+  @Override
+  public void destroy() {}
+
+  @Override
+  public void doFilter(
+      ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+      throws IOException, ServletException {
+    String path = ((HttpServletRequest) servletRequest).getServletPath();
+
+    // Continue to servlets architecture if the prefix matches:
+    // 1. Servlet Request (api)
+    // 2. Google Request (_ah)
+    if (path.startsWith("/api") || path.startsWith("/_ah")) {
+      filterChain.doFilter(servletRequest, servletResponse);
+    } else {
+      // Redirects back to index.html if the request wasn't intended for a
+      // servlet.
+      RequestDispatcher dispatcher = servletRequest.getRequestDispatcher("/");
+      dispatcher.forward(servletRequest, servletResponse);
+    }
+  }
+}

--- a/server/src/main/java/com/google/codeu/servlets/LoginServlet.java
+++ b/server/src/main/java/com/google/codeu/servlets/LoginServlet.java
@@ -1,20 +1,24 @@
-/**
+/*
  * Copyright 2019 Google Inc.
  *
- * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.google.codeu.servlets;
 
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
+import com.google.codeu.utils.ServletLink;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -22,7 +26,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /** Redirects the user to the Google login page or their page if they're already logged in. */
-@WebServlet("/gap/login")
+@WebServlet(ServletLink.LOGIN)
 public class LoginServlet extends HttpServlet {
 
   @Override
@@ -33,13 +37,13 @@ public class LoginServlet extends HttpServlet {
     // If the user is already logged in, redirect to their page
     if (userService.isUserLoggedIn()) {
       String user = userService.getCurrentUser().getEmail();
-      response.sendRedirect("/userpage?user=" + user);
+      response.sendRedirect(ServletLink.USER_PAGE + "?user=" + user);
       return;
     }
 
     // Redirect to Google login page. That page will then redirect back to /login,
     // which will be handled by the above if statement.
-    String googleLoginUrl = userService.createLoginURL("/gap/login");
+    String googleLoginUrl = userService.createLoginURL("/api/login");
     response.sendRedirect(googleLoginUrl);
   }
 }

--- a/server/src/main/java/com/google/codeu/servlets/LoginStatusServlet.java
+++ b/server/src/main/java/com/google/codeu/servlets/LoginStatusServlet.java
@@ -18,6 +18,7 @@ package com.google.codeu.servlets;
 
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
+import com.google.codeu.utils.ServletLink;
 import com.google.gson.JsonObject;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
@@ -28,7 +29,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Returns login data as JSON, e.g. {"isLoggedIn": true, "username": "alovelace@codeustudents.com"}
  */
-@WebServlet("/gap/login-status")
+@WebServlet(ServletLink.LOGIN_STATUS)
 public class LoginStatusServlet extends HttpServlet {
 
   @Override

--- a/server/src/main/java/com/google/codeu/servlets/LogoutServlet.java
+++ b/server/src/main/java/com/google/codeu/servlets/LogoutServlet.java
@@ -18,6 +18,7 @@ package com.google.codeu.servlets;
 
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
+import com.google.codeu.utils.ServletLink;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -25,13 +26,13 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /** Redirects the user to the Google logout page, which then redirects to the homepage. */
-@WebServlet("/gap/logout")
+@WebServlet(ServletLink.LOGOUT)
 public class LogoutServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     UserService userService = UserServiceFactory.getUserService();
-    String googleLogoutUrl = userService.createLogoutURL("/");
+    String googleLogoutUrl = userService.createLogoutURL(ServletLink.INDEX);
     response.sendRedirect(googleLogoutUrl);
   }
 }

--- a/server/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/server/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -1,22 +1,26 @@
-/**
+/*
  * Copyright 2019 Google Inc.
  *
- * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.google.codeu.servlets;
 
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
 import com.google.codeu.data.Datastore;
 import com.google.codeu.data.Message;
+import com.google.codeu.utils.ServletLink;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.List;
@@ -28,7 +32,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
 
 /** Handles fetching and saving {@link Message} instances. */
-@WebServlet("/gap/messages")
+@WebServlet(ServletLink.MESSAGES)
 public class MessageServlet extends HttpServlet {
 
   private Datastore datastore;
@@ -44,7 +48,6 @@ public class MessageServlet extends HttpServlet {
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-
     response.setContentType("application/json");
 
     String user = request.getParameter("user");
@@ -65,10 +68,9 @@ public class MessageServlet extends HttpServlet {
   /** Stores a new {@link Message}. */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-
     UserService userService = UserServiceFactory.getUserService();
     if (!userService.isUserLoggedIn()) {
-      response.sendRedirect("/");
+      response.sendRedirect(ServletLink.INDEX);
       return;
     }
 
@@ -78,6 +80,6 @@ public class MessageServlet extends HttpServlet {
     Message message = new Message(user, text);
     datastore.storeMessage(message);
 
-    response.sendRedirect("/userpage?user=" + user);
+    response.sendRedirect(ServletLink.USER_PAGE + "?user=" + user);
   }
 }

--- a/server/src/main/java/com/google/codeu/utils/ServletLink.java
+++ b/server/src/main/java/com/google/codeu/utils/ServletLink.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.codeu.utils;
+
+/** Constants for all servlet links. */
+public final class ServletLink {
+
+  /** Private Constructor. */
+  private ServletLink() {}
+
+  /** Url prefix for all servlet links. */
+  public static final String SERVLET_PREFIX = "/api";
+
+  /** Url handled by {@link LoginServlet}. */
+  public static final String LOGIN = SERVLET_PREFIX + "/login";
+  /** Url handled by {@link LoginStatusServlet}. */
+  public static final String LOGIN_STATUS = SERVLET_PREFIX + "/login-status";
+
+  /** Url handled by {@link LogoutServlet}. */
+  public static final String LOGOUT = SERVLET_PREFIX + "/logout";
+
+  /** Url handled by {@link MessageServlet}. */
+  public static final String MESSAGES = SERVLET_PREFIX + "/messages";
+
+  /** Index url handled by the client. */
+  public static final String INDEX = "/";
+  /** User page url handled by the client. */
+  public static final String USER_PAGE = "/userpage";
+}

--- a/server/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/server/src/main/webapp/WEB-INF/appengine-web.xml
@@ -17,7 +17,7 @@
 
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
   <!-- [CHANGE] Application id corresponds to the App Engine id. -->
-  <application>YOUR_PROJECT_ID</application>
+  <application>codeu-react-starter</application>
   <!-- [BUILD] the version to deploy a production build. -->
   <version>dev</version>
   <threadsafe>false</threadsafe>


### PR DESCRIPTION
Servlet urls are still handled by the servlet. Allows direct linking to localhost:8080/aboutus rather than forcing the user to go to localhost:8080 and click the "About The Team" link.

Issue: https://github.com/fluffysheep-codeu/codeu-react-starter/issues/4
PR: https://github.com/fluffysheep-codeu/codeu-react-starter/pulls/1